### PR TITLE
reduce size of HTML by only including search index on /search

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,6 +5,5 @@
     {{- partial "header.html" . -}}
     {{- block "main" . }}{{- end }}
     {{- partial "scripts.html" . -}}
-    {{- partial "search-index.html" . -}}
   </body>
 </html>

--- a/layouts/search/list.html
+++ b/layouts/search/list.html
@@ -10,4 +10,5 @@
         </div>
     </div>
 </div>
+{{- partial "search-index.html" . -}}
 {{ end }}


### PR DESCRIPTION
Thanks for releasing this theme! When viewing the generated HTML, I noticed that the search index is included on every page. This increases the size of the generated HTML significantly, especially when there are many posts.

From what I understand of the plugin, it only needs to be on the /search page to work. This PR moves the partial search-index.html from baseof to search/list.